### PR TITLE
add rspec select right option

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,4 @@
+--require spec_helper
 --format documentation
 --color
---require spec_helper
+

--- a/lib/qiita_org/post.rb
+++ b/lib/qiita_org/post.rb
@@ -10,6 +10,7 @@ class QiitaPost
     @option = (option == "open")? "qiita" : option
   end
 
+  public
   def get_title_tags()
     @conts = File.read(@src)
     @title = @conts.match(/\#\+(TITLE|title|Title): (.+)/)[2] || "テスト"

--- a/spec/qiita_org_spec.rb
+++ b/spec/qiita_org_spec.rb
@@ -5,10 +5,20 @@ RSpec.describe QiitaOrg do
 end
 
 RSpec.describe QiitaPost do
-  it "does something useful" do
-    ['qiita','open','teams','private','public'].each do |ele|
-      p ele
-      p QiitaPost::select_option(ele)
+  before :each do
+    @post = QiitaPost.new('test','hoge')
+  end
+  
+  it "select right option" do
+
+    [['qiita',["https://qiita.com/", false]],
+     ["private", ["https://qiita.com/", true]],
+     ["teams", [nil, false]], # "https://nishitani.qiita.com/", false]],
+     ["open",["https://qiita.com/", false]],
+     ["public",["https://qiita.com/", false]]
+     ].each do |val,res|
+      p [val,res]
+      expect(@post.select_option(val)).to eq res
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require "bundler/setup"
 require "qiita_org"
+require "qiita_org/post"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
rspecにselect_optionをチェックするspecを書いてみました．
```ruby
  it "select right option" do
13
14    [['qiita',["https://qiita.com/", false]],
15     ["private", ["https://qiita.com/", true]],
16     ["teams", [nil, false]], # "https://nishitani.qiita.com/", false]],                            
17     ["open",["https://qiita.com/", false]],
18     ["public",["https://qiita.com/", false]]
19     ].each do |val,res|
20      p [val,res]
21      expect(@post.select_option(val)).to eq res
22    end
```
 としたところ，
["open", ["https://qiita.com/", false]]
  select right option (FAILED - 1)
で
       expected: ["https://qiita.com/", false]
            got: ["https://qiita.com/", true]
と返ってきました．修正をお願いします．
それと，teamsのurlがnilで返ってくるのは仕様的にどうかと思います．
統一できるように修正されてはどうですか．

もし，深い理由があるならそれを書いてください．
