### PR TITLE
rev post.rb for notitle, tags

### DIFF
--- a/lib/qiita_org/post.rb
+++ b/lib/qiita_org/post.rb
@@ -19,19 +19,19 @@ class QiitaPost
   public
   def get_title_tags()
     @conts = File.read(@src)
-    @title = @conts.match(/\#\+(TITLE|title|Title): (.+)/)[2] || "テスト"
-    m = []
+    m = @conts.match(/\#\+(TITLE|title|Title): (.+)/)
+    @title = m ?  m[2] : "テスト"
     @tags = if m = @conts.match(/\#\+(TAG|tag|Tag|tags|TAGS|Tags): (.+)/)
-        if m[2].count(",") >= 5
-          puts "The maximum number of tag is five. Please delete some tags.".red
-          exit
-        end
-        m[2].split(",").inject([]) do |l, c|
-          l << { name: c.strip } #, versions: []}
-        end
-      else
-        [{ name: "hoge" }] #, versions: [] }]
-      end
+              if m[2].count(",") >= 5
+                puts "The maximum number of tag is five. Please delete some tags.".red
+                exit
+              end
+              m[2].split(",").inject([]) do |l, c|
+                 l << { name: c.strip } #, versions: []}
+              end
+            else
+              [{ name: "hoge" }] #, versions: [] }]
+            end
     p @tags
   end
 


### PR DESCRIPTION
title, tagsがないorgをあげようとした時に，
```
qiita post emacs_j.org public                                                                 9.2s
ProductName:	Mac OS X
ProductVersion:	10.15.7
BuildVersion:	19H2
["in qiita_org.rb", ["emacs_j.org", "public"]]
"emacs_j.org"
"public"
"/Users/bob"
Traceback (most recent call last):
	9: from /Users/bob/.rbenv/versions/2.7.1/bin/qiita:23:in `<main>'
	8: from /Users/bob/.rbenv/versions/2.7.1/bin/qiita:23:in `load'
	7: from /Users/bob/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/qiita_org-0.1.14/exe/qiita:5:in `<top (required)>'
	6: from /Users/bob/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/thor-1.0.1/lib/thor/base.rb:485:in `start'
	5: from /Users/bob/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/thor-1.0.1/lib/thor.rb:392:in `dispatch'
	4: from /Users/bob/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/thor-1.0.1/lib/thor/invocation.rb:127:in `invoke_command'
	3: from /Users/bob/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/thor-1.0.1/lib/thor/command.rb:27:in `run'
	2: from /Users/bob/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/qiita_org-0.1.14/lib/qiita_org.rb:43:in `post'
	1: from /Users/bob/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/qiita_org-0.1.14/lib/qiita_org/post.rb:153:in `run'
/Users/bob/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/qiita_org-0.1.14/lib/qiita_org/post.rb:22:in `get_title_tags': undefined method `[]' for nil:NilClass (NoMethodError)
```
となって死にます．

post.rbのtitleを読む判定文あたりを変更しました．よろしく．
