### PR TITLE
fix: twitter In-Buffer Settings

### DIFF
--- a/lib/qiita_org/post.rb
+++ b/lib/qiita_org/post.rb
@@ -66,7 +66,7 @@ class QiitaPost
 
   # check twitter post
   def select_twitter(conts, option)
-    return option == "public" && conts.match?(/^\#\+twitter:\s*on$/i)
+    option == "public" && conts.match?(/^\#\+twitter:\s*on$/i)
   end
 
   def select_option(option)

--- a/lib/qiita_org/post.rb
+++ b/lib/qiita_org/post.rb
@@ -66,18 +66,7 @@ class QiitaPost
 
   # check twitter post
   def select_twitter(conts, option)
-    m = []
-    twitter = false
-    if option == "public"
-      m = conts.match(/\#\+(twitter|Twitter|TWITTER): (.+)/)
-      if m[2] == 'on' || m[2] == 'On' || m[2] == 'ON'
-        twitter = true
-      else
-        twitter = false
-      end
-    end
-    twitter
-    return twitter
+    return option == "public" && conts.match(/^\#\+twitter:\s*on$/i)
   end
 
   def select_option(option)

--- a/lib/qiita_org/post.rb
+++ b/lib/qiita_org/post.rb
@@ -66,7 +66,7 @@ class QiitaPost
 
   # check twitter post
   def select_twitter(conts, option)
-    return option == "public" && conts.match(/^\#\+twitter:\s*on$/i)
+    return option == "public" && conts.match?(/^\#\+twitter:\s*on$/i)
   end
 
   def select_option(option)


### PR DESCRIPTION
現在、 In-Buffer Settings に `#+twitter: ` が無いとエラーが出ます。

In-Buffer Settings に `#+twitter: ` が無いと、 変数 `m` に `nil`が代入され、 `m[2]` で `undefined method '[]' for nil:NilClass ` が発生して異常終了します。

そこで、 `select_twitter` の処理方法を変え、 In-Buffer Settings  に `#+twitter: ` が無くとも動作するようにした。